### PR TITLE
fix: cleanup downloaded source files before syncing to S3

### DIFF
--- a/src/packager.ts
+++ b/src/packager.ts
@@ -1,6 +1,6 @@
 import path, { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmdirSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, unlinkSync } from 'node:fs';
 import { readdir, mkdir } from 'node:fs/promises';
 import { toUrl, toUrlOrUndefined } from './util';
 import mv from 'mv';
@@ -75,7 +75,7 @@ export async function prepare(
 
 export async function cleanup(stagingDir: string) {
   console.log(`Cleaning up staging directory: ${stagingDir}`);
-  await rmdirSync(stagingDir);
+  await rmSync(stagingDir, { recursive: true, force: true });
 }
 
 export async function download(


### PR DESCRIPTION
This PR fixes the issue where we upload the source files to Shaka packager to the S3 bucket and cleaning up job dir once finished. Also added some better logging if s3 upload failes